### PR TITLE
Expand backend and frontend features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # Compras
 Sistema de Gestão de Compras - Estilo Kanban com Agentes de IA
+
+## Desenvolvimento
+
+### Backend
+
+```bash
+cd backend
+npm install # requer internet
+npm run dev
+```
+
+Endpoints principais:
+- `/auth/login`
+- `/cards`
+- `/suppliers`
+- `/departments`
+- `/payment-methods`
+
+### Frontend
+
+```bash
+cd frontend
+npm install # requer internet
+npm start
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "compras-backend",
+  "version": "1.0.0",
+  "main": "dist/app.js",
+  "scripts": {
+    "start": "node dist/app.js",
+    "dev": "ts-node src/app.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "body-parser": "^1.20.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.0.4",
+    "@types/express": "^4.17.17",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/node": "^20.4.2"
+  }
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,28 @@
+import express from 'express';
+import bodyParser from 'body-parser';
+import swaggerUi from 'swagger-ui-express';
+import authRoutes from './routes/auth';
+import cardRoutes from './routes/cards';
+import supplierRoutes from './routes/suppliers';
+import deptRoutes from './routes/departments';
+import methodRoutes from './routes/paymentMethods';
+import webhookRoutes from './routes/webhooks';
+import { swaggerSpec } from './swagger';
+
+const app = express();
+app.use(bodyParser.json());
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.use('/auth', authRoutes);
+app.use('/cards', cardRoutes);
+app.use('/suppliers', supplierRoutes);
+app.use('/departments', deptRoutes);
+app.use('/payment-methods', methodRoutes);
+app.use('/webhooks', webhookRoutes);
+
+app.get('/', (_req, res) => {
+  res.json({ message: 'Compras API' });
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server running on port ${port}`));

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+const secret = process.env.JWT_SECRET || 'secret';
+
+export interface AuthRequest extends Request {
+  user?: any;
+}
+
+export function authenticate(req: AuthRequest, res: Response, next: NextFunction) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided' });
+  try {
+    req.user = jwt.verify(token, secret);
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+export function authorize(roles: string[]) {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    next();
+  };
+}

--- a/backend/src/models/card.ts
+++ b/backend/src/models/card.ts
@@ -1,0 +1,38 @@
+export type Phase =
+  | 'Solicitação'
+  | 'Aprovação de Solicitação'
+  | 'Cotação'
+  | 'Aprovação de Compra'
+  | 'Pedido de Compra'
+  | 'Conclusão de Compra'
+  | 'Recebimento de Material'
+  | 'Arquivado';
+
+export interface Card {
+  id: number;
+  title: string;
+  requesterId: number;
+  departmentId: number;
+  costCenter: string;
+  category: string;
+  urgency: 'Baixo' | 'Médio' | 'Alto';
+  justification: string;
+  phase: Phase;
+  approverA1Id?: number;
+  approvedA1?: boolean;
+  cotacao?: {
+    buyerId: number;
+    supplierIds: number[];
+    totalValue: number;
+    paymentMethodId: number;
+  };
+  approverA2Id?: number;
+  purchaseOrder?: {
+    date: string;
+    files: string[];
+    notes: string;
+  };
+  receiverId?: number;
+}
+
+export const cards: Card[] = [];

--- a/backend/src/models/department.ts
+++ b/backend/src/models/department.ts
@@ -1,0 +1,10 @@
+export interface Department {
+  id: number;
+  name: string;
+  costCenters: string[];
+}
+
+export const departments: Department[] = [
+  { id: 1, name: 'TI', costCenters: ['CC001'] },
+  { id: 2, name: 'Financeiro', costCenters: ['CC002'] }
+];

--- a/backend/src/models/paymentMethod.ts
+++ b/backend/src/models/paymentMethod.ts
@@ -1,0 +1,13 @@
+export interface PaymentMethod {
+  id: number;
+  name: string;
+}
+
+export const paymentMethods: PaymentMethod[] = [
+  { id: 1, name: 'Boleto' },
+  { id: 2, name: 'Cheque' },
+  { id: 3, name: 'Transferência Bancária' },
+  { id: 4, name: 'Cartão de Crédito' },
+  { id: 5, name: 'Dinheiro' },
+  { id: 6, name: 'Pix' }
+];

--- a/backend/src/models/supplier.ts
+++ b/backend/src/models/supplier.ts
@@ -1,0 +1,10 @@
+export interface Supplier {
+  id: number;
+  name: string;
+  cnpj: string;
+  contact: string;
+  email: string;
+  services: string;
+}
+
+export const suppliers: Supplier[] = [];

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -1,0 +1,21 @@
+export type Role = 'admin' | 'requester' | 'buyer' | 'approverA1' | 'approverA2';
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  password: string;
+  role: Role;
+  departments: number[];
+}
+
+export const users: User[] = [
+  {
+    id: 1,
+    name: 'Admin',
+    email: 'admin@example.com',
+    password: 'password',
+    role: 'admin',
+    departments: [1]
+  }
+];

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import jwt from 'jsonwebtoken';
+import { users } from '../models/user';
+
+const secret = process.env.JWT_SECRET || 'secret';
+const router = Router();
+
+router.post('/login', (req, res) => {
+  const { email, password } = req.body;
+  const user = users.find(u => u.email === email && u.password === password);
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+  const token = jwt.sign({ id: user.id, role: user.role }, secret);
+  res.json({ token });
+});
+
+export default router;

--- a/backend/src/routes/cards.ts
+++ b/backend/src/routes/cards.ts
@@ -1,0 +1,93 @@
+import { Router } from 'express';
+import { authenticate, authorize, AuthRequest } from '../middleware/auth';
+import { cards, Card, Phase } from '../models/card';
+import { suppliers } from '../models/supplier';
+
+const router = Router();
+
+router.get('/', authenticate, (_req, res) => {
+  res.json(cards);
+});
+
+router.post('/', authenticate, (req: AuthRequest, res) => {
+  const id = cards.length + 1;
+  const {
+    title,
+    departmentId,
+    costCenter,
+    category,
+    urgency,
+    justification
+  } = req.body;
+  const card: Card = {
+    id,
+    title,
+    requesterId: req.user.id,
+    departmentId,
+    costCenter,
+    category,
+    urgency,
+    justification,
+    phase: 'Solicitação'
+  };
+  cards.push(card);
+  res.status(201).json(card);
+});
+
+router.put('/:id/phase', authenticate, (req: AuthRequest, res) => {
+  const card = cards.find(c => c.id === parseInt(req.params.id));
+  if (!card) return res.status(404).json({ message: 'Not found' });
+  const next: Phase = req.body.phase;
+  card.phase = next;
+  res.json(card);
+});
+
+router.post('/:id/cotacao', authenticate, authorize(['buyer']), (req: AuthRequest, res) => {
+  const card = cards.find(c => c.id === parseInt(req.params.id));
+  if (!card) return res.status(404).json({ message: 'Not found' });
+  card.cotacao = {
+    buyerId: req.user.id,
+    supplierIds: req.body.supplierIds,
+    totalValue: req.body.totalValue,
+    paymentMethodId: req.body.paymentMethodId
+  };
+  card.phase = 'Aprovação de Compra';
+  res.json(card);
+});
+
+router.post('/:id/approveA1', authenticate, authorize(['approverA1']), (req: AuthRequest, res) => {
+  const card = cards.find(c => c.id === parseInt(req.params.id));
+  if (!card) return res.status(404).json({ message: 'Not found' });
+  card.approverA1Id = req.user.id;
+  card.approvedA1 = req.body.approved;
+  card.phase = req.body.approved ? 'Cotação' : 'Arquivado';
+  res.json(card);
+});
+
+export default router;
+
+router.post('/:id/approveA2', authenticate, authorize(['approverA2']), (req: AuthRequest, res) => {
+  const card = cards.find(c => c.id === parseInt(req.params.id));
+  if (!card) return res.status(404).json({ message: 'Not found' });
+  card.approverA2Id = req.user.id;
+  card.phase = 'Pedido de Compra';
+  res.json(card);
+});
+
+router.post('/:id/pedido', authenticate, authorize(['buyer']), (req: AuthRequest, res) => {
+  const card = cards.find(c => c.id === parseInt(req.params.id));
+  if (!card) return res.status(404).json({ message: 'Not found' });
+  card.purchaseOrder = req.body;
+  card.phase = 'Conclusão de Compra';
+  res.json(card);
+});
+
+router.post('/:id/recebimento', authenticate, (req: AuthRequest, res) => {
+  const card = cards.find(c => c.id === parseInt(req.params.id));
+  if (!card) return res.status(404).json({ message: 'Not found' });
+  card.receiverId = req.user.id;
+  card.phase = 'Arquivado';
+  res.json(card);
+});
+
+export default router;

--- a/backend/src/routes/departments.ts
+++ b/backend/src/routes/departments.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { departments } from '../models/department';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json(departments);
+});
+
+export default router;

--- a/backend/src/routes/paymentMethods.ts
+++ b/backend/src/routes/paymentMethods.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { paymentMethods } from '../models/paymentMethod';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json(paymentMethods);
+});
+
+export default router;

--- a/backend/src/routes/suppliers.ts
+++ b/backend/src/routes/suppliers.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { suppliers, Supplier } from '../models/supplier';
+import { authenticate, authorize, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.get('/', authenticate, (_req, res) => {
+  res.json(suppliers);
+});
+
+router.post('/', authenticate, authorize(['admin', 'buyer']), (req: AuthRequest, res) => {
+  const id = suppliers.length + 1;
+  const supplier: Supplier = { id, ...req.body };
+  suppliers.push(supplier);
+  res.status(201).json(supplier);
+});
+
+export default router;

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/event', (req, res) => {
+  console.log('Webhook received', req.body);
+  res.json({ ok: true });
+});
+
+export default router;

--- a/backend/src/swagger.ts
+++ b/backend/src/swagger.ts
@@ -1,0 +1,8 @@
+export const swaggerSpec = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Compras API',
+    version: '1.0.0'
+  },
+  paths: {}
+};

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "compras-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "axios": "^1.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.0.4",
+    "ts-loader": "^9.4.4",
+    "webpack": "^5.86.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Compras Kanban</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="/bundle.js"></script>
+</body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+interface Card {
+  id: number;
+  title: string;
+  phase: string;
+}
+
+const phases = [
+  'Solicitação',
+  'Aprovação de Solicitação',
+  'Cotação',
+  'Aprovação de Compra',
+  'Pedido de Compra',
+  'Conclusão de Compra',
+  'Recebimento de Material',
+  'Arquivado'
+];
+
+const App: React.FC = () => {
+  const [cards, setCards] = useState<Card[]>([]);
+  const [title, setTitle] = useState('');
+  const [token, setToken] = useState(localStorage.getItem('token') || '');
+
+  useEffect(() => {
+    if (token) {
+      axios.get('/cards', { headers: { Authorization: `Bearer ${token}` } }).then(res => setCards(res.data));
+    }
+  }, [token]);
+
+  const login = async () => {
+    const res = await axios.post('/auth/login', { email: 'admin@example.com', password: 'password' });
+    localStorage.setItem('token', res.data.token);
+    setToken(res.data.token);
+  };
+
+  const createCard = async () => {
+    const res = await axios.post('/cards', { title }, { headers: { Authorization: `Bearer ${token}` } });
+    setCards([...cards, res.data]);
+    setTitle('');
+  };
+
+  if (!token) {
+    return <button onClick={login}>Login</button>;
+  }
+
+  return (
+    <div>
+      <div>
+        <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Título" />
+        <button onClick={createCard}>Criar Solicitação</button>
+      </div>
+      <div style={{ display: 'flex' }}>
+        {phases.map(phase => (
+          <div key={phase} style={{ margin: '0 10px' }}>
+            <h3>{phase}</h3>
+            {cards
+              .filter(c => c.phase === phase)
+              .map(c => (
+                <div key={c.id} style={{ border: '1px solid #ccc', padding: 4 }}>
+                  {c.title}
+                </div>
+              ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,31 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/
+      }
+    ]
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public')
+    },
+    historyApiFallback: true,
+    port: 3001,
+    proxy: {
+      '/': 'http://localhost:3000'
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- document backend endpoints
- wire up Express app with more routes
- model cards with more fields
- define sample user roles
- implement card flow endpoints
- add basic React login and card creation
- fix webpack proxy config

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `cd backend && npm test` *(fails: Missing script)*
- `cd frontend && npm test` *(fails: Missing script)*
- `npm install --silent` in frontend *(fails: network restricted)*
- `npm install --silent` in backend *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_685ed8e6e49c83278299da6da872fb66